### PR TITLE
docs(nextpage): add ceatorReplied field

### DIFF
--- a/content/docs/api-documentation/index.md
+++ b/content/docs/api-documentation/index.md
@@ -156,7 +156,8 @@ Response:
             "likeCount": 0, // The number of likes the comment has
             "pinned": false, // Whether or not the comment is pinned
             "thumbnail": "https://pipedproxy-bom.kavin.rocks/...", // The thumbnail of the comment
-            "verified": false // Whether or not the author of the comment is verified
+            "verified": false, // Whether or not the author of the comment is verified
+            "creatorReplied": false // Whether the creator has replied to the comment
         }
     ], // A list of comments
     "disabled": false, // Whether or not the comments are disabled


### PR DESCRIPTION
Since `/comments` and `/nextpage/comments` both return the comments, both should contain the same comments fields. I forgot to add `creatorReplied` in https://github.com/TeamPiped/documentation/pull/15.