### PR TITLE
docs(comment): add channelOwner field

### DIFF
--- a/content/docs/api-documentation/index.md
+++ b/content/docs/api-documentation/index.md
@@ -126,7 +126,8 @@ Response:
             "pinned": false, // Whether or not the comment is pinned
             "thumbnail": "https://pipedproxy-bom.kavin.rocks/...", // The thumbnail of the comment
             "verified": false, // Whether or not the author of the comment is verified
-            "creatorReplied": false // Whether the creator has replied to the comment 
+            "creatorReplied": false, // Whether the creator has replied to the comment
+	    "channelOwner": false // Whether the comment author is the channel owner 
         }
     ], // A list of comments
     "disabled": false, // Whether or not the comments are disabled
@@ -156,7 +157,8 @@ Response:
             "likeCount": 0, // The number of likes the comment has
             "pinned": false, // Whether or not the comment is pinned
             "thumbnail": "https://pipedproxy-bom.kavin.rocks/...", // The thumbnail of the comment
-            "verified": false // Whether or not the author of the comment is verified
+            "verified": false, // Whether or not the author of the comment is verified
+	    "channelOwner": false // Whether the comment author is the channel owner
         }
     ], // A list of comments
     "disabled": false, // Whether or not the comments are disabled


### PR DESCRIPTION
Adds the `channelOwner` field added in https://github.com/TeamPiped/Piped-Backend/pull/727.