### PR TITLE
Update Traefik Example

### DIFF
--- a/content/docs/self-hosting/index.md
+++ b/content/docs/self-hosting/index.md
@@ -86,7 +86,7 @@ This must be applied on the nginx container.
 ```
 labels:
   - "traefik.enable=true"
-  - "traefik.http.routers.piped.rule=Host(`hostname`,`hostname2`,`hostname3`)"
+  - "traefik.http.routers.piped.rule=Host(`piped.yourdomain.tld`) || Host(`pipedapi.yourdomain.tld`) || Host(`pipedproxy.yourdomain.tld`)"
   - "traefik.http.routers.piped.entrypoints=web"
 ```
 


### PR DESCRIPTION
A recent update to Traefik has made a breaking change with this configuration where the three piped domains can not be separated by commas anymore, instead the proper syntax is now an individual Host variable for each domain separated by && or ||, in this example I've opted for || as that works on my machine. Documentation for this syntax can be found here: https://doc.traefik.io/traefik/v3.0/routing/routers/#rule

I only found this because I updated my homelab recently and found a 404 error when trying to access Piped, so I'm hoping I catch this before any extraneous issues get made about it.